### PR TITLE
Remove thread race condition on index

### DIFF
--- a/Tangle.Net/Cryptography/AddressGenerator.cs
+++ b/Tangle.Net/Cryptography/AddressGenerator.cs
@@ -87,17 +87,17 @@
     /// </returns>
     public List<Address> GetAddresses(int startIndex, int count)
     {
+
       var result = new List<Address>();
 
       // since address generation takes very long, we will do it parallel (if there are any concerns regarding this, please communicate them)
       startIndex--;
       Parallel.For(
-        0,
-        count,
+        startIndex,
+        startIndex + count - 1,
         i =>
           {
-            startIndex++;
-            result.Add(this.GetAddress(startIndex));
+            result.Add(this.GetAddress(i));
           });
 
       // sort by index to ensure correct order


### PR DESCRIPTION
The existing code alters startIndex within the code block executed by the thread. Changed this to use the value passed by Parallel.For when creating the tasks.