### PR TITLE
Ensure no new objects are created when retrieving Tag.Empty or Hash.E…

### DIFF
--- a/Tangle.Net/Entity/Hash.cs
+++ b/Tangle.Net/Entity/Hash.cs
@@ -20,6 +20,13 @@
 
     #endregion
 
+    #region Fields
+    /// <summary>
+    /// Gets the empty.
+    /// </summary>
+    public static readonly Hash Empty = new Hash(new string('9', Length));
+    #endregion
+
     #region Constructors and Destructors
 
     /// <summary>
@@ -48,21 +55,6 @@
     public Hash()
       : this(string.Empty)
     {
-    }
-
-    #endregion
-
-    #region Public Properties
-
-    /// <summary>
-    /// Gets the empty.
-    /// </summary>
-    public static Hash Empty
-    {
-      get
-      {
-        return new Hash("999999999999999999999999999999999999999999999999999999999999999999999999999999999");
-      }
     }
 
     #endregion

--- a/Tangle.Net/Entity/Tag.cs
+++ b/Tangle.Net/Entity/Tag.cs
@@ -16,6 +16,14 @@
 
     #endregion
 
+    #region Fields
+    /// <summary>
+    /// Gets the empty.
+    /// </summary>
+    public static readonly Tag Empty = new Tag();
+    #endregion
+
+
     #region Constructors and Destructors
 
     /// <summary>
@@ -48,19 +56,5 @@
 
     #endregion
 
-    #region Public Properties
-
-    /// <summary>
-    /// Gets the empty.
-    /// </summary>
-    public static Tag Empty
-    {
-      get
-      {
-        return new Tag();
-      }
-    }
-
-    #endregion
   }
 }


### PR DESCRIPTION
Cache Tag.Empty and Hash.Empty as readonly static fields, so we don't create a new object every time we read the value.