### PR TITLE
Ensure at least 1 thread is used when running on a single CPU computer

### DIFF
--- a/Tangle.Net/ProofOfWork/CpuPowDiver.cs
+++ b/Tangle.Net/ProofOfWork/CpuPowDiver.cs
@@ -340,7 +340,8 @@
 
       if (numberOfThreads <= 0)
       {
-        numberOfThreads = Environment.ProcessorCount - 1;
+        //Use up to a maximum of all processors but one, and a minimum of one processors
+        numberOfThreads = Math.Max(Environment.ProcessorCount - 1, 1);
       }
 
       var tasks = new List<Task>();


### PR DESCRIPTION
The current code will not run any threads if there is only 1 CPU on the machine. The intention is to use between 1 and (ProcessorCount - 1) threads.