### PR TITLE
CpuPowDriver was using zero threads on single processor systems

### DIFF
--- a/Tangle.Net/Tangle.Net/ProofOfWork/CpuPowDiver.cs
+++ b/Tangle.Net/Tangle.Net/ProofOfWork/CpuPowDiver.cs
@@ -340,7 +340,9 @@
 
       if (numberOfThreads <= 0)
       {
-        numberOfThreads = Environment.ProcessorCount - 1;
+        // Use one thread for each processor on the system except one
+        // We must ensure we use at least 1
+        numberOfThreads = Math.Max(Environment.ProcessorCount - 1, 1);
       }
 
       var tasks = new List<Task>();


### PR DESCRIPTION
The current code will not run any threads if there is only 1 CPU on the machine. The original code uses between 1 and (ProcessorCount - 1) threads.