### PR TITLE
Bugfix in RestIotaExtendedRepository.GetTransfers()

### DIFF
--- a/Tangle.Net/Tangle.Net/Repository/RestIotaExtendedRepository.cs
+++ b/Tangle.Net/Tangle.Net/Repository/RestIotaExtendedRepository.cs
@@ -571,7 +571,7 @@
       var transactions = addressStopIndex == 0
                            ? this.FindUsedAddressesWithTransactions(seed, securityLevel, addressStartIndex).AssociatedTransactionHashes
                            : this.FindTransactionsByAddresses(
-                             this.AddressGenerator.GetAddresses(seed, securityLevel, 0, addressStartIndex - addressStopIndex + 1)).Hashes;
+                             this.AddressGenerator.GetAddresses(seed, securityLevel, 0, addressStopIndex - addressStartIndex + 1)).Hashes;
 
       return this.GetBundles(transactions, includeInclusionStates);
     }
@@ -582,7 +582,7 @@
       var transactions = addressStopIndex == 0
                            ? (await this.FindUsedAddressesWithTransactionsAsync(seed, securityLevel, addressStartIndex)).AssociatedTransactionHashes
                            : (await this.FindTransactionsByAddressesAsync(
-                                this.AddressGenerator.GetAddresses(seed, securityLevel, 0, addressStartIndex - addressStopIndex + 1))).Hashes;
+                                this.AddressGenerator.GetAddresses(seed, securityLevel, 0, addressStopIndex - addressStartIndex + 1))).Hashes;
 
       return await this.GetBundlesAsync(transactions, includeInclusionStates);
     }


### PR DESCRIPTION
Hi, I was testing some stuf in the Tangle.Net repository, and stumbled on something I guess is a bug. Inside the GetTransfers and GetTransfersAsync methods the addressStartIndex is subtracted with the addressStopIndex. This resulted in a negative number as the "count" parameter inside Enumerable.Range().

Could you take a look at this and check if this is indeed an issue?