### PR TITLE
Upgrade packages for Tangle.Net.Standard project

### DIFF
--- a/Tangle.Net.Standard/Tangle.Net.Area.Codes/Tangle.Net.Area.Codes.csproj
+++ b/Tangle.Net.Standard/Tangle.Net.Area.Codes/Tangle.Net.Area.Codes.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenLocationCode" Version="2.0.0" />
-    <PackageReference Include="Tangle.Net.Standard" Version="3.0.0" />
+    <PackageReference Include="Tangle.Net.Standard" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Tangle.Net.Standard/Tangle.Net.Standard.Mam/Tangle.Net.Standard.Mam.csproj
+++ b/Tangle.Net.Standard/Tangle.Net.Standard.Mam/Tangle.Net.Standard.Mam.csproj
@@ -49,7 +49,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Tangle.Net.Standard" Version="3.0.0" />
+    <PackageReference Include="Tangle.Net.Standard" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tangle.Net.Standard/Tangle.Net.Standard.Zmq/Tangle.Net.Standard.Zmq.csproj
+++ b/Tangle.Net.Standard/Tangle.Net.Standard.Zmq/Tangle.Net.Standard.Zmq.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="NetMQ" Version="4.0.0.1" />
-    <PackageReference Include="Tangle.Net.Standard" Version="3.0.1" />
+    <PackageReference Include="Tangle.Net.Standard" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Tangle.Net.Standard/Tangle.Net.Standard/Tangle.Net.Standard.csproj
+++ b/Tangle.Net.Standard/Tangle.Net.Standard/Tangle.Net.Standard.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>3.0.3.0</Version>
+    <Version>3.1.0.0</Version>
     <Description>.NET Standard 2.0 IOTA Library C# Port</Description>
     <Authors>Felandil</Authors>
     <Company>Felandil</Company>
@@ -12,8 +12,8 @@
     <PackageProjectUrl>https://github.com/Felandil/tangle-.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/Felandil/tangle-.net/blob/master/LICENSE</PackageLicenseUrl>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <AssemblyVersion>3.0.3.0</AssemblyVersion>
-    <FileVersion>3.0.3.0</FileVersion>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <FileVersion>3.1.0.0</FileVersion>
     <PackageTags>iota csharp</PackageTags>  
   </PropertyGroup>
 

--- a/Tangle.Net.Standard/Tangle.Net.Standard/Tangle.Net.Standard.csproj
+++ b/Tangle.Net.Standard/Tangle.Net.Standard/Tangle.Net.Standard.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>3.0.3.0</Version>
+    <Version>3.1.0.1</Version>
     <Description>.NET Standard 2.0 IOTA Library C# Port</Description>
     <Authors>Felandil</Authors>
     <Company>Felandil</Company>
@@ -12,8 +12,8 @@
     <PackageProjectUrl>https://github.com/Felandil/tangle-.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/Felandil/tangle-.net/blob/master/LICENSE</PackageLicenseUrl>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <AssemblyVersion>3.0.3.0</AssemblyVersion>
-    <FileVersion>3.0.3.0</FileVersion>
+    <AssemblyVersion>3.1.0.1</AssemblyVersion>
+    <FileVersion>3.1.0.1</FileVersion>
     <PackageTags>iota csharp</PackageTags>  
   </PropertyGroup>
 
@@ -110,8 +110,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.4" />
-    <PackageReference Include="RestSharp" Version="106.2.1" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
+    <PackageReference Include="RestSharp" Version="106.6.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tangle.Net/Tangle.Net.Mam.Unit.Tests/Tangle.Net.Mam.Unit.Tests.csproj
+++ b/Tangle.Net/Tangle.Net.Mam.Unit.Tests/Tangle.Net.Mam.Unit.Tests.csproj
@@ -56,7 +56,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Tangle.Net, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Tangle.Net.3.0.0\lib\net461\Tangle.Net.dll</HintPath>
+      <HintPath>..\packages\Tangle.Net.3.1.0\lib\net461\Tangle.Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tangle.Net/Tangle.Net.Mam.Unit.Tests/packages.config
+++ b/Tangle.Net/Tangle.Net.Mam.Unit.Tests/packages.config
@@ -4,5 +4,5 @@
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
   <package id="RestSharp" version="106.2.1" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-  <package id="Tangle.Net" version="3.0.0" targetFramework="net461" />
+  <package id="Tangle.Net" version="3.1.0" targetFramework="net461" />
 </packages>

--- a/Tangle.Net/Tangle.Net.Mam/Tangle.Net.Mam.csproj
+++ b/Tangle.Net/Tangle.Net.Mam/Tangle.Net.Mam.csproj
@@ -52,7 +52,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Tangle.Net, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Tangle.Net.3.0.0\lib\net461\Tangle.Net.dll</HintPath>
+      <HintPath>..\packages\Tangle.Net.3.1.0\lib\net461\Tangle.Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tangle.Net/Tangle.Net.Mam/packages.config
+++ b/Tangle.Net/Tangle.Net.Mam/packages.config
@@ -4,5 +4,5 @@
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
   <package id="RestSharp" version="106.2.1" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-  <package id="Tangle.Net" version="3.0.0" targetFramework="net461" />
+  <package id="Tangle.Net" version="3.1.0" targetFramework="net461" />
 </packages>

--- a/Tangle.Net/Tangle.Net.Zmq/Tangle.Net.Zmq.csproj
+++ b/Tangle.Net/Tangle.Net.Zmq/Tangle.Net.Zmq.csproj
@@ -53,7 +53,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Tangle.Net, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Tangle.Net.3.0.0\lib\net461\Tangle.Net.dll</HintPath>
+      <HintPath>..\packages\Tangle.Net.3.1.0\lib\net461\Tangle.Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tangle.Net/Tangle.Net.Zmq/packages.config
+++ b/Tangle.Net/Tangle.Net.Zmq/packages.config
@@ -5,5 +5,5 @@
   <package id="NetMQ" version="4.0.0.1" targetFramework="net461" />
   <package id="RestSharp" version="106.2.1" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-  <package id="Tangle.Net" version="3.0.0" targetFramework="net461" />
+  <package id="Tangle.Net" version="3.1.0" targetFramework="net461" />
 </packages>

--- a/Tangle.Net/Tangle.Net/Cryptography/Converter.cs
+++ b/Tangle.Net/Tangle.Net/Cryptography/Converter.cs
@@ -231,7 +231,7 @@
     /// </returns>
     public static byte[] ConvertTritsToBytes(int[] trits)
     {
-      return ConvertBigIntToBytes(BigInteger.Parse(ConvertTritsToBigInt(trits, 0, Constants.TritHashLength).ToString()));
+      return ConvertBigIntToBytes(ConvertTritsToBigInt(trits, 0, Constants.TritHashLength));
     }
 
     /// <summary>

--- a/Tangle.Net/Tangle.Net/Tangle.Net.nuspec
+++ b/Tangle.Net/Tangle.Net/Tangle.Net.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Tangle.Net</id>
-    <version>3.0.3.0</version>
+    <version>3.1.0.0</version>
     <title>.NET 4.6.1 IOTA Library C# Port</title>
     <authors>Felandil</authors>
     <owners>Felandil</owners>

--- a/Tangle.Net/Tangle.Net/Utils/Extensions.cs
+++ b/Tangle.Net/Tangle.Net/Utils/Extensions.cs
@@ -8,8 +8,8 @@
 
   using RestSharp;
   using RestSharp.Deserializers;
-
-  using Tangle.Net.Cryptography;
+    using RestSharp.Serialization.Json;
+    using Tangle.Net.Cryptography;
   using Tangle.Net.Entity;
   using Tangle.Net.Repository.Responses;
 
@@ -127,7 +127,7 @@
 
     public static NodeErrorResponse ToNodeError(this IRestResponse response)
     {
-      return new JsonDeserializer().Deserialize<NodeErrorResponse>(response);
+      return new JsonSerializer().Deserialize<NodeErrorResponse>(response);
     }
   }
 }

--- a/Tangle.Net/Tangle.Net/Utils/Extensions.cs
+++ b/Tangle.Net/Tangle.Net/Utils/Extensions.cs
@@ -1,10 +1,8 @@
 ﻿namespace Tangle.Net.Utils
 {
   using System.Collections.Generic;
-  using System.Globalization;
   using System.Linq;
-
-  using Org.BouncyCastle.Math;
+  using System.Numerics;
 
   using RestSharp;
   using RestSharp.Deserializers;
@@ -12,8 +10,6 @@
   using Tangle.Net.Cryptography;
   using Tangle.Net.Entity;
   using Tangle.Net.Repository.Responses;
-
-  using BigInteger = System.Numerics.BigInteger;
 
   /// <summary>
   /// The string extensions.


### PR DESCRIPTION
# Reason of Change

When using this library with `io.nem1.sdk`, there is a conflict of RestSharp library version where newer version of RestSharp removed `JsonDeserializer` class.

# Changes
- Upgrade *RestSharp* to v`106.6.10`
- Upgrade *Portable.BouncyCastle* to v`1.8.5`
- Fix: Change `JsonDeserializer` to `JsonSerializer` 
- Bump a minor version upgrade